### PR TITLE
Fix problem with coverage and Python 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ commands =
     coverage report -i --omit='.tox/*'
 deps =
     pytest
-    coverage
+    # Latest version supported by Python 3.4
+    coverage==4.5.4
 
 [testenv:begin]
 commands = coverage erase


### PR DESCRIPTION
Coverage >= 5.0.0 does not support Python 3.4 which causes
an error when Python 3.4 has coverage 4.5.4 and all newer Pythons
have coverage 5.0.0 (or higher) because these versions of coverage
use backward incompatible data storage.

We can drop this when we drop support for Python 3.4.